### PR TITLE
Fix couple miscallenous issues: unused variables + default argument in implementation

### DIFF
--- a/src/SparkFun_PCA9536_Arduino_Library.cpp
+++ b/src/SparkFun_PCA9536_Arduino_Library.cpp
@@ -51,9 +51,6 @@ boolean PCA9536::begin(void)
 
 PCA9536_error_t PCA9536::begin(TwoWire &wirePort) 
 {
-    uint8_t systemControl = 0;
-    PCA9536_error_t retVal;
-
     _deviceAddress = PCA9536_ADDRESS;
     _i2cPort = &wirePort;
 
@@ -133,7 +130,7 @@ uint8_t PCA9536::digitalRead(uint8_t pin)
     return read(pin);
 }
 
-PCA9536_error_t PCA9536::invert(uint8_t pin, PCA9536_invert_t inversion = PCA9536_INVERT)
+PCA9536_error_t PCA9536::invert(uint8_t pin, PCA9536_invert_t inversion)
 {
     PCA9536_error_t err;
     uint8_t invertRegister = 0;


### PR DESCRIPTION
Noticed this when working with platform.io + esp8266 project:

* Compiler shows warnings about unused variables
* Default arguments [should only be in declaration][1]. With some stricter compiler
  settings it actually fails to compile.

[1]: https://stackoverflow.com/questions/15591756/c-default-arguments-declaration