### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -16,7 +16,7 @@ SparkFun_PCA9536_Arduino_Library	KEYWORD1
 setDebugStream	KEYWORD2
 invert	KEYWORD2
 revert	KEYWORD2
-readReg KEYWORD2
+readReg	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab, the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords